### PR TITLE
Addition of csv.openstring plus other minor fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Leyland, Geoff
+Martin, Kevin

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2013 Incremental IP Limited
+Copyright (c) 2014 Kevin Martin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ controlling how the file is read:
 + `buffer_size` controls the size of the blocks the file is read in.  The
   default is 4096, which is what `pagesize` says on my system.
 
+`csv.openstring` works exactly like `csv.open` except the first argument
+is the contents of the csv file. In this case `buffer_size` is set to
+the length of the string.
 
 ## 3. Requirements
 

--- a/test-data/blank-line.csv
+++ b/test-data/blank-line.csv
@@ -1,1 +1,2 @@
 this,file,ends,with,a,blank,line
+


### PR DESCRIPTION
Hi Geoff,

Still don't really know what I'm doing with git/github, but following a guide, and hopefully this is ok? I've tried to stick to your coding standard as I understand it.

I don't really like the way I've done the tests, but didn't want to rewrite it without talking to you. At the moment I just run each passed test with csv.open through csv.openstring with the default buffer size (i.e. the string length)

See commit log below for details of changes

Thanks,
Kev

----------------------------  Commit Log ----------------------

Added an openstring function, by wrapping the string in an object
that supports read(bytes) and passing the object to the underlying
code. Modified all the tests to run with both open and openstring.

Changed the default buffer size in csv.lua to match the value in the
README, and added the crucial blank line to test-data/blankline.csv
